### PR TITLE
Check if attribute is None before looking for its raw property.

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1038,7 +1038,7 @@ class Device(object):
                         if 'power on time' in line:
                             self.diags['Power_On_Hours'] = line.split(':')[1].split(' ')[1]
         # map temperature
-        if self.temperature is None and self.attributes[194]:
+        if self.temperature is None:
             # in this case the disk is probably ata
             try:
                 self.temperature = int(self.attributes[194].raw)

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1042,7 +1042,7 @@ class Device(object):
             # in this case the disk is probably ata
             try:
                 self.temperature = int(self.attributes[194].raw)
-            except ValueError:
+            except (ValueError, AttributeError):
                 pass
         # Now that we have finished the update routine, if we did not find a runnning selftest
         # nuke the self._test_ECD and self._test_progress

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1038,7 +1038,7 @@ class Device(object):
                         if 'power on time' in line:
                             self.diags['Power_On_Hours'] = line.split(':')[1].split(' ')[1]
         # map temperature
-        if self.temperature is None:
+        if self.temperature is None and self.attributes[194]:
             # in this case the disk is probably ata
             try:
                 self.temperature = int(self.attributes[194].raw)


### PR DESCRIPTION
This was a non-issue before since we had a catch-all `try/except` but now we specifically only catch `ValueError` and hence this AttributeError raises to the top.

Since @piotrgl was the one to review this I would request him to do this one too
Ticket: #18866