### PR TITLE
DeviceList: assorted fixes

### DIFF
--- a/pySMART/device_list.py
+++ b/pySMART/device_list.py
@@ -93,7 +93,7 @@ class DeviceList(object):
         `DeviceList` as `Device` objects.
         """
         cmd = Popen([SMARTCTL_PATH, '--scan-open'], stdout=PIPE, stderr=PIPE)
-        _stdout, _stderr = cmd.communicate()
+        _stdout, _stderr = [i.decode('utf8') for i in cmd.communicate()]
         for line in _stdout.split('\n'):
             if not ('failed:' in line or line == ''):
                 name = line.split(' ')[0].replace('/dev/', '')

--- a/pySMART/device_list.py
+++ b/pySMART/device_list.py
@@ -29,6 +29,7 @@ from subprocess import Popen, PIPE
 
 # pySMART module imports
 from .device import Device
+from .utils import SMARTCTL_PATH
 
 
 class DeviceList(object):
@@ -91,7 +92,7 @@ class DeviceList(object):
         Scans system busses for attached devices and add them to the
         `DeviceList` as `Device` objects.
         """
-        cmd = Popen(['/usr/local/sbin/smartctl', '--scan-open'], stdout=PIPE, stderr=PIPE)
+        cmd = Popen([SMARTCTL_PATH, '--scan-open'], stdout=PIPE, stderr=PIPE)
         _stdout, _stderr = cmd.communicate()
         for line in _stdout.split('\n'):
             if not ('failed:' in line or line == ''):


### PR DESCRIPTION
* use `SMARTCTL_PATH` instead of hardcoding `/usr/local/sbin/smartctl`, so downstream distributions will have to patch one place instead of two
* decode smartctl's reply (fix DeviceList on Python 3)