### PR TITLE
Get capacity of first namespace for NVMe devices

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -878,7 +878,8 @@ class Device(object):
                 continue
             if 'Firmware Version' in line or 'Revision' in line:
                 self.firmware = line.split(':')[1].lstrip().rstrip()
-            if 'User Capacity' in line:
+            if 'User Capacity' in line or 'Namespace 1 Size/Capacity' in line:
+                # TODO: support for multiple NVMe namespaces
                 self.capacity = (
                     line.replace(']', '[').split('[')[1].lstrip().rstrip())
             if 'SMART support' in line:


### PR DESCRIPTION
This works well enough for consumer grade NVMe devices, which usually have only one namespace.  It would be nice to have support for drives with multiple namespaces in the future, but for now this closes #25