### PR TITLE
Fixed temperature detection issue with drives that report multiple temperatures.

### DIFF
--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1047,7 +1047,8 @@ class Device(object):
                 self.diags['Non-Medium_Errors'] = line.split(':')[1].strip()
             if 'Accumulated power on time' in line:
                 self.diags['Power_On_Hours'] = line.split(':')[1].split(' ')[1]
-            if self.temperature is None and ('Current Drive Temperature' in line or ('Temperature' in line and interface =='nvme')):
+            if 'Current Drive Temperature' in line or ('Temperature:' in 
+line and interface == 'nvme'):
                 try:
                     self.temperature = int(line.split(':')[-1].strip().split()[0])
                 except ValueError:

--- a/pySMART/device.py
+++ b/pySMART/device.py
@@ -1047,7 +1047,7 @@ class Device(object):
                 self.diags['Non-Medium_Errors'] = line.split(':')[1].strip()
             if 'Accumulated power on time' in line:
                 self.diags['Power_On_Hours'] = line.split(':')[1].split(' ')[1]
-            if 'Current Drive Temperature' in line or ('Temperature' in line and interface =='nvme'):
+            if self.temperature is None and ('Current Drive Temperature' in line or ('Temperature' in line and interface =='nvme')):
                 try:
                     self.temperature = int(line.split(':')[-1].strip().split()[0])
                 except ValueError:


### PR DESCRIPTION
The existing code did not check if the device temperature value had already been set during the current update call, meaning that it would set the temperature value to the last one in the `smartctl` output. In NVMe devices that expose multiple temperature sensors, this results in the temperature being set to that of one of the sensors, rather than the actual reported "overall" temperature value.

This PR changes the behaviour to use the first reported value from the `smartctl` output, which should be the "Temperature" value reported in the NVMe Log SMART Health Information output.