### PR TITLE
Update TraceLogger.findCaller() to python 3.8

### DIFF
--- a/pySMART/utils.py
+++ b/pySMART/utils.py
@@ -40,7 +40,7 @@ class TraceLogger(logging.Logger):
     def trace(self, msg, *args, **kwargs):
         self.log(TRACE, msg, *args, **kwargs)
 
-    def findCaller(self, stack_info=False):
+    def findCaller(self, stack_info=False, stacklevel=1):
         """
         Overload built-in findCaller method
         to omit not only logging/__init__.py but also the current file
@@ -50,6 +50,12 @@ class TraceLogger(logging.Logger):
         # IronPython isn't run with -X:Frames.
         if f is not None:
             f = f.f_back
+        orig_f = f
+        while f and stacklevel > 1:
+            f = f.f_back
+            stacklevel -= 1
+        if not f:
+            f = orig_f
         rv = "(unknown file)", 0, "(unknown function)", None
         while hasattr(f, "f_code"):
             co = f.f_code


### PR DESCRIPTION
Python 3.8 updated the logging API for findCaller() adding the
stacklevel=1 argument.

See: https://github.com/python/cpython/commit/dde9fdbe453925279ac3d2a6a72102f6f9ef247c#diff-c11fc567cf5b6e518eb855c23b5599bc
Closes: #30